### PR TITLE
Add support for widgets and makeProxyTransport.

### DIFF
--- a/lean-client-js-core/src/commands.ts
+++ b/lean-client-js-core/src/commands.ts
@@ -99,6 +99,12 @@ export interface InfoSource {
 
 export type GoalState = string;
 
+export interface WidgetData {
+    html: WidgetComponent;
+    line: number;
+    column: number;
+}
+
 export interface InfoRecord {
     'full-id'?: string;
     text?: string;
@@ -107,7 +113,7 @@ export interface InfoRecord {
     source?: InfoSource;
     tactic_params?: string[];
     state?: GoalState;
-    widget?: {html: WidgetComponent};
+    widget?: WidgetData;
 }
 
 export interface InfoResponse extends CommandResponse {
@@ -215,12 +221,12 @@ export interface LongSleepRequest extends Request {
 
 interface WidgetEventRecordSuccess {
     status: 'success';
-    widget: {html: WidgetComponent};
+    widget: WidgetData;
 }
 
 interface WidgetEventRecordEdit {
     status: 'edit';
-    widget: {html: WidgetComponent};
+    widget: WidgetData;
     /** Some text to insert after the widget's comma. */
     action: string;
 }

--- a/lean-client-js-core/src/commands.ts
+++ b/lean-client-js-core/src/commands.ts
@@ -107,6 +107,7 @@ export interface InfoRecord {
     source?: InfoSource;
     tactic_params?: string[];
     state?: GoalState;
+    widget?: {html: WidgetComponent};
 }
 
 export interface InfoResponse extends CommandResponse {
@@ -210,4 +211,77 @@ export interface SleepRequest extends Request {
 
 export interface LongSleepRequest extends Request {
     command: 'long_sleep';
+}
+
+interface WidgetEventRecordSuccess {
+    status: 'success';
+    widget: {html: WidgetComponent};
+}
+
+interface WidgetEventRecordEdit {
+    status: 'edit';
+    widget: {html: WidgetComponent};
+    /** Some text to insert after the widget's comma. */
+    action: string;
+}
+
+interface WidgetEventRecordInvalid {
+    status: 'invalid_handler';
+}
+interface WidgetEventRecordError {
+    status: 'error';
+    message: string;
+}
+
+export type WidgetEventRecord =
+    | WidgetEventRecordSuccess
+    | WidgetEventRecordInvalid
+    | WidgetEventRecordEdit
+    | WidgetEventRecordError;
+
+export interface WidgetEventResponse extends CommandResponse {
+    record: WidgetEventRecord;
+}
+
+export interface WidgetEventHandler {
+    /** handler id */
+    h: number;
+    /** route */
+    r: number[];
+}
+
+export interface WidgetElement {
+    /** tag */
+    t: 'div' | 'span' | 'hr' | 'button' | 'input'; // ... etc ... any string
+    /** children */
+    c: WidgetHtml[];
+    /** attributes */
+    a: { [k: string]: any } | null;
+    /** events */
+    e: {
+        'onClick'?: WidgetEventHandler;
+        'onMouseEnter'?: WidgetEventHandler;
+        'onMouseLeave'?: WidgetEventHandler;
+    };
+    /** tooltip */
+    tt?: WidgetHtml;
+}
+export interface WidgetComponent {
+    /** children */
+    c: WidgetHtml[];
+}
+export type WidgetHtml =
+    | WidgetComponent
+    | string
+    | WidgetElement
+    | null;
+
+export interface WidgetEventRequest extends Request {
+    command: 'widget_event';
+    kind: 'onClick' | 'onMouseEnter' | 'onMouseLeave' | 'onChange';
+    handler: WidgetEventHandler;
+    args: { type: 'unit' } | { type: 'string'; value: string };
+    file_name: string;
+    line: number;
+    column: number;
 }

--- a/lean-client-js-core/src/server.ts
+++ b/lean-client-js-core/src/server.ts
@@ -1,7 +1,8 @@
 import {AdditionalMessageResponse, AllHoleCommandsRequest, AllHoleCommandsResponse, AllMessagesResponse,
     CheckingMode, CommandResponse, CompleteRequest, CompleteResponse, CurrentTasksResponse,
     ErrorResponse, FileRoi, HoleCommandsRequest, HoleCommandsResponse, HoleRequest, HoleResponse, InfoRequest,
-    InfoResponse, Message, Request, RoiRequest, SearchRequest, SearchResponse, SyncRequest} from './commands';
+    InfoResponse, Message, Request, RoiRequest, SearchRequest, SearchResponse, SyncRequest,
+    WidgetEventRequest, WidgetEventResponse} from './commands';
 import {Event} from './event';
 import {Connection, Transport, TransportError} from './transport';
 
@@ -46,6 +47,7 @@ export class Server {
     }
 
     send(req: InfoRequest): Promise<InfoResponse>;
+    send(req: WidgetEventRequest): Promise<WidgetEventResponse>;
     send(req: CompleteRequest): Promise<CompleteResponse>;
     send(req: SyncRequest): Promise<CommandResponse>;
     send(req: RoiRequest): Promise<CommandResponse>;
@@ -118,6 +120,61 @@ export class Server {
 
             this.conn = null;
         }
+    }
+
+    /** Creates a Transport that utilises the same Connection as this server (but without seq_num clashes).
+     * This is useful if you have a need for multiple `Server` objects using the same underlying lean process.
+     * This happens, for example, in the vscode extension where there is a Server instance in the InfoView
+     * and a Server instance in the extension.
+     */
+    makeProxyTransport(): Transport {
+        class ProxyConnection implements Connection {
+            error: Event<TransportError> = new Event();
+            jsonMessage: Event<any> = new Event();
+            private subscriptions: Array<{dispose()}> = [];
+            private translate: Map<number, number> = new Map();
+            constructor(private parent: Server) {
+                this.subscriptions.push(
+                    this.error,
+                    this.jsonMessage,
+                    this.parent.conn.jsonMessage.on((x) => {
+                        if (x.seq_num) {
+                            const {seq_num, ...rest} = x;
+                            const oldSeqNum = this.translate.get(seq_num);
+                            if (seq_num !== undefined) {
+                                this.translate.delete(seq_num);
+                                this.jsonMessage.fire({seq_num : oldSeqNum, ...rest});
+                            }
+                        } else {
+                            this.jsonMessage.fire(x);
+                        }
+                    }),
+                    parent.conn.error.on((x) => this.error.fire(x)),
+                );
+            }
+            get alive() { return this.parent.alive(); }
+            send(jsonMsg: any) {
+                const {seq_num, ...req} = jsonMsg;
+                if (seq_num) {
+                    const newSeqNum = this.parent.currentSeqNum++;
+                    // tell the parent to do nothing when it gets this seq num.
+                    const p = new Promise((res, reject) =>
+                      this.parent.sentRequests.set(newSeqNum, {resolve : res, reject}));
+                    this.translate.set(newSeqNum, seq_num);
+                    this.parent.conn.send({seq_num : newSeqNum, ...req});
+                } else {
+                    throw new Error('expected message to have a seq num');
+                }
+            }
+            dispose() {
+                for (const s of this.subscriptions) {
+                    s.dispose();
+                }
+            }
+        }
+        return {
+            connect : () => new ProxyConnection(this),
+        };
     }
 
     private onMessage(msg: any) {


### PR DESCRIPTION
Some of this is currently repeated in the vscode extension. However I think that the Lean widget API is currently stable enough to reflect it here. If this version of Server is used with a version of lean without widgets, then it is still backwards compatible (the `widget` field on info response will just be none and sending a `WidgetEventRequest` will cause the promise to be rejected). It's also backwards compatible with older versions of lean-client-js.

Additionally, I added a `Server.prototype.makeProxyTransport()` which will return a Transport that can be used to initialise `Server` instances without breaking sequence numbering. This is needed in the vscode extension since the infoview and extension need to share a connection to the lean server but they can't use the same Server instance because the infoview is in an iframe.