### PR TITLE
Add a widgets flag to InfoRequest

### DIFF
--- a/lean-client-js-core/src/commands.ts
+++ b/lean-client-js-core/src/commands.ts
@@ -89,6 +89,8 @@ export interface InfoRequest extends Request {
     file_name: string;
     line: number;
     column: number;
+    /** if set to true, asks lean to also return widget information. */
+    widgets?: boolean;
 }
 
 export interface InfoSource {

--- a/lean-client-js-core/src/server.ts
+++ b/lean-client-js-core/src/server.ts
@@ -75,8 +75,8 @@ export class Server {
         return promise;
     }
 
-    info(file: string, line: number, column: number): Promise<InfoResponse> {
-        return this.send({command: 'info', file_name: file, line, column});
+    info(file: string, line: number, column: number, widgets = true): Promise<InfoResponse> {
+        return this.send({command: 'info', file_name: file, line, column, widgets});
     }
 
     sync(file: string, contents: string): Promise<CommandResponse> {


### PR DESCRIPTION
adds an additional `widgets?: boolean` flag to `InfoRequest` so that in the future you can turn off and on widgets per request rather than when the server is initialised.