### PR TITLE
Allow passing extra arguments along in lean-language-server

### DIFF
--- a/lean-language-server/package-lock.json
+++ b/lean-language-server/package-lock.json
@@ -1,137 +1,139 @@
 {
-	"name": "lean-language-server",
-	"version": "2.0.1",
-	"lockfileVersion": 2,
-	"requires": true,
-	"packages": {
-		"": {
-			"version": "2.0.0",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@types/node": "^9.4.6",
-				"vscode-languageserver": "^3.5.0",
-				"vscode-uri": "^1.0.1"
-			},
-			"bin": {
-				"lean-language-server": "lib/index.js"
-			}
-		},
-		"node_modules/@types/node": {
-			"version": "9.4.6",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.6.tgz",
-			"integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ=="
-		},
-		"node_modules/lean-client-js-core": {
-			"version": "1.2.12",
-			"resolved": "https://registry.npmjs.org/lean-client-js-core/-/lean-client-js-core-1.2.12.tgz",
-			"integrity": "sha512-m2TWFAbokO/ar2hhZupOLMpGf/dAtghRSCbR9xyaYRo37UfztjZ7AAXGm9BF99o/0WZ3Bl2na8ZkYk63H/qnNw==",
-			"dependencies": {
-				"@types/node": "^9.4.6"
-			}
-		},
-		"node_modules/lean-client-js-node": {
-			"version": "1.2.12",
-			"resolved": "https://registry.npmjs.org/lean-client-js-node/-/lean-client-js-node-1.2.12.tgz",
-			"integrity": "sha512-hjsfa0cCQ5ZW3OwvWmbFcgdVmNfIXUfG2r/bXnCyS0yTOlnhFjor6xTud6gNUAQp5FxGMZd0WpwxOMmbYiVaHg==",
-			"dependencies": {
-				"@types/node": "^9.4.6",
-				"lean-client-js-core": "^1.2.12"
-			}
-		},
-		"node_modules/vscode-jsonrpc": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.5.0.tgz",
-			"integrity": "sha1-hyOdnhZrLXNSJFuKgTWXgEwdY6o=",
-			"engines": {
-				"node": ">=4.0.0 || >=6.0.0"
-			}
-		},
-		"node_modules/vscode-languageserver": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-3.5.0.tgz",
-			"integrity": "sha1-0oCZvG3dqMHdFrcH5FThsd2uDbo=",
-			"dependencies": {
-				"vscode-languageserver-protocol": "^3.5.0",
-				"vscode-uri": "^1.0.1"
-			},
-			"bin": {
-				"installServerIntoExtension": "bin/installServerIntoExtension"
-			}
-		},
-		"node_modules/vscode-languageserver-protocol": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.5.0.tgz",
-			"integrity": "sha1-Bnxcvidwl5U5jRGWksl+u6FFIgk=",
-			"dependencies": {
-				"vscode-jsonrpc": "^3.5.0",
-				"vscode-languageserver-types": "^3.5.0"
-			}
-		},
-		"node_modules/vscode-languageserver-types": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.5.0.tgz",
-			"integrity": "sha1-5I15li8LjgLelV4/UkkI4rGcA3Q="
-		},
-		"node_modules/vscode-uri": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.1.tgz",
-			"integrity": "sha1-Eahr7+rDxKo+wIYjZRo8gabQu8g="
-		}
-	},
-	"dependencies": {
-		"@types/node": {
-			"version": "9.4.6",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.6.tgz",
-			"integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ=="
-		},
-		"lean-client-js-core": {
-			"version": "1.2.12",
-			"resolved": "https://registry.npmjs.org/lean-client-js-core/-/lean-client-js-core-1.2.12.tgz",
-			"integrity": "sha512-m2TWFAbokO/ar2hhZupOLMpGf/dAtghRSCbR9xyaYRo37UfztjZ7AAXGm9BF99o/0WZ3Bl2na8ZkYk63H/qnNw==",
-			"requires": {
-				"@types/node": "^9.4.6"
-			}
-		},
-		"lean-client-js-node": {
-			"version": "https://registry.npmjs.org/lean-client-js-node/-/lean-client-js-node-1.2.12.tgz",
-			"integrity": "sha512-hjsfa0cCQ5ZW3OwvWmbFcgdVmNfIXUfG2r/bXnCyS0yTOlnhFjor6xTud6gNUAQp5FxGMZd0WpwxOMmbYiVaHg==",
-			"requires": {
-				"@types/node": "^9.4.6",
-				"lean-client-js-core": "^1.2.12"
-			}
-		},
-		"vscode-jsonrpc": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.5.0.tgz",
-			"integrity": "sha1-hyOdnhZrLXNSJFuKgTWXgEwdY6o="
-		},
-		"vscode-languageserver": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-3.5.0.tgz",
-			"integrity": "sha1-0oCZvG3dqMHdFrcH5FThsd2uDbo=",
-			"requires": {
-				"vscode-languageserver-protocol": "^3.5.0",
-				"vscode-uri": "^1.0.1"
-			}
-		},
-		"vscode-languageserver-protocol": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.5.0.tgz",
-			"integrity": "sha1-Bnxcvidwl5U5jRGWksl+u6FFIgk=",
-			"requires": {
-				"vscode-jsonrpc": "^3.5.0",
-				"vscode-languageserver-types": "^3.5.0"
-			}
-		},
-		"vscode-languageserver-types": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.5.0.tgz",
-			"integrity": "sha1-5I15li8LjgLelV4/UkkI4rGcA3Q="
-		},
-		"vscode-uri": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.1.tgz",
-			"integrity": "sha1-Eahr7+rDxKo+wIYjZRo8gabQu8g="
-		}
-	}
+  "name": "lean-language-server",
+  "version": "2.0.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "2.0.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^9.4.6",
+        "lean-client-js-node": "^2.0.1",
+        "vscode-languageserver": "^3.5.0",
+        "vscode-uri": "^1.0.1"
+      },
+      "bin": {
+        "lean-language-server": "lib/index.js"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "9.6.61",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.61.tgz",
+      "integrity": "sha512-/aKAdg5c8n468cYLy2eQrcR5k6chlbNwZNGUj3TboyPa2hcO2QAJcfymlqPzMiRj8B6nYKXjzQz36minFE0RwQ=="
+    },
+    "node_modules/lean-client-js-core": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/lean-client-js-core/-/lean-client-js-core-2.0.1.tgz",
+      "integrity": "sha512-QGNAAB+RnFF2JQSw5mj6iInwhKVDPf1pYII/YU+SmWMNCO1R+n55ti8LCZcDeUvZlu/pybGgwZ9/3rq9cd10oA==",
+      "dependencies": {
+        "@types/node": "^9.4.6"
+      }
+    },
+    "node_modules/lean-client-js-node": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/lean-client-js-node/-/lean-client-js-node-2.0.1.tgz",
+      "integrity": "sha512-NQrIkV1CAW/fKzhI9qUc2687pSS/1L546ntJrkK9gv4qoxXXJBxQeagqTaV8O7T4Bsy2ow/JdsqIJ0LQ6ajCGw==",
+      "dependencies": {
+        "@types/node": "^9.4.6",
+        "lean-client-js-core": "^2.0.1"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.5.0.tgz",
+      "integrity": "sha1-hyOdnhZrLXNSJFuKgTWXgEwdY6o=",
+      "engines": {
+        "node": ">=4.0.0 || >=6.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-3.5.0.tgz",
+      "integrity": "sha1-0oCZvG3dqMHdFrcH5FThsd2uDbo=",
+      "dependencies": {
+        "vscode-languageserver-protocol": "^3.5.0",
+        "vscode-uri": "^1.0.1"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.5.0.tgz",
+      "integrity": "sha1-Bnxcvidwl5U5jRGWksl+u6FFIgk=",
+      "dependencies": {
+        "vscode-jsonrpc": "^3.5.0",
+        "vscode-languageserver-types": "^3.5.0"
+      }
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.5.0.tgz",
+      "integrity": "sha1-5I15li8LjgLelV4/UkkI4rGcA3Q="
+    },
+    "node_modules/vscode-uri": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.1.tgz",
+      "integrity": "sha1-Eahr7+rDxKo+wIYjZRo8gabQu8g="
+    }
+  },
+  "dependencies": {
+    "@types/node": {
+      "version": "9.6.61",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.61.tgz",
+      "integrity": "sha512-/aKAdg5c8n468cYLy2eQrcR5k6chlbNwZNGUj3TboyPa2hcO2QAJcfymlqPzMiRj8B6nYKXjzQz36minFE0RwQ=="
+    },
+    "lean-client-js-core": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/lean-client-js-core/-/lean-client-js-core-2.0.1.tgz",
+      "integrity": "sha512-QGNAAB+RnFF2JQSw5mj6iInwhKVDPf1pYII/YU+SmWMNCO1R+n55ti8LCZcDeUvZlu/pybGgwZ9/3rq9cd10oA==",
+      "requires": {
+        "@types/node": "^9.4.6"
+      }
+    },
+    "lean-client-js-node": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/lean-client-js-node/-/lean-client-js-node-2.0.1.tgz",
+      "integrity": "sha512-NQrIkV1CAW/fKzhI9qUc2687pSS/1L546ntJrkK9gv4qoxXXJBxQeagqTaV8O7T4Bsy2ow/JdsqIJ0LQ6ajCGw==",
+      "requires": {
+        "@types/node": "^9.4.6",
+        "lean-client-js-core": "^2.0.1"
+      }
+    },
+    "vscode-jsonrpc": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.5.0.tgz",
+      "integrity": "sha1-hyOdnhZrLXNSJFuKgTWXgEwdY6o="
+    },
+    "vscode-languageserver": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-3.5.0.tgz",
+      "integrity": "sha1-0oCZvG3dqMHdFrcH5FThsd2uDbo=",
+      "requires": {
+        "vscode-languageserver-protocol": "^3.5.0",
+        "vscode-uri": "^1.0.1"
+      }
+    },
+    "vscode-languageserver-protocol": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.5.0.tgz",
+      "integrity": "sha1-Bnxcvidwl5U5jRGWksl+u6FFIgk=",
+      "requires": {
+        "vscode-jsonrpc": "^3.5.0",
+        "vscode-languageserver-types": "^3.5.0"
+      }
+    },
+    "vscode-languageserver-types": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.5.0.tgz",
+      "integrity": "sha1-5I15li8LjgLelV4/UkkI4rGcA3Q="
+    },
+    "vscode-uri": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.1.tgz",
+      "integrity": "sha1-Eahr7+rDxKo+wIYjZRo8gabQu8g="
+    }
+  }
 }

--- a/lean-language-server/src/index.ts
+++ b/lean-language-server/src/index.ts
@@ -27,7 +27,9 @@ const documents = new TextDocuments();
 documents.listen(connection);
 
 connection.onInitialize((params): InitializeResult => {
-    server.transport = new ProcessTransport('lean', params.rootPath, []);
+    const extraArgs = process.argv.indexOf('--');
+    const argv = extraArgs === -1 ? [] : process.argv.slice(extraArgs + 1)
+    server.transport = new ProcessTransport('lean', params.rootPath, argv);
     server.connect();
     sendRoi();
     return {


### PR DESCRIPTION
Does so by allowing writing e.g.:

    $ lean-language-server --stdio -- -M 4096 -T 10000

which will provide the extra `argv` down to Lean.

This is 'wrong' in the sense that it should really use the LSP-native
way to do so, which is responding to `workspace/configuration` requests,
but the current version of lean-language-server uses a quite old version
of vscode-languageserver, and I couldn't get it to work on a newer one
without significant changes. For another time...