### PR TITLE
Update to a modern vscode-languageserver

### DIFF
--- a/lean-language-server/package-lock.json
+++ b/lean-language-server/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "lean-language-server",
-  "version": "2.0.4",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.0.3",
+      "version": "3.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/node": "^9.4.6",
-        "lean-client-js-node": "^2.0.1",
-        "vscode-languageserver": "^3.5.0",
-        "vscode-uri": "^1.0.1"
+        "@types/node": "^16.6.1",
+        "lean-client-js-node": "^2.0.4",
+        "vscode-languageserver": "^7.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-uri": "^3.0.2"
       },
       "bin": {
         "lean-language-server": "lib/index.js"
@@ -21,26 +22,36 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "9.6.61",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.61.tgz",
-      "integrity": "sha512-/aKAdg5c8n468cYLy2eQrcR5k6chlbNwZNGUj3TboyPa2hcO2QAJcfymlqPzMiRj8B6nYKXjzQz36minFE0RwQ=="
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.6.1.tgz",
+      "integrity": "sha512-Sr7BhXEAer9xyGuCN3Ek9eg9xPviCF2gfu9kTfuU2HkTVAMYSDeX40fvpmo72n5nansg3nsBjuQBrsS28r+NUw=="
     },
     "node_modules/lean-client-js-core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/lean-client-js-core/-/lean-client-js-core-2.0.1.tgz",
-      "integrity": "sha512-QGNAAB+RnFF2JQSw5mj6iInwhKVDPf1pYII/YU+SmWMNCO1R+n55ti8LCZcDeUvZlu/pybGgwZ9/3rq9cd10oA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/lean-client-js-core/-/lean-client-js-core-2.0.4.tgz",
+      "integrity": "sha512-jLZErvAHF0mfU+rC8UhPQdhypz2mwj0UgMhMYpRcY0srRU684mxcOcCERNd3D6crGJBEAM9QIN54m2HzWZ69YQ==",
       "dependencies": {
         "@types/node": "^9.4.6"
       }
     },
+    "node_modules/lean-client-js-core/node_modules/@types/node": {
+      "version": "9.6.61",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.61.tgz",
+      "integrity": "sha512-/aKAdg5c8n468cYLy2eQrcR5k6chlbNwZNGUj3TboyPa2hcO2QAJcfymlqPzMiRj8B6nYKXjzQz36minFE0RwQ=="
+    },
     "node_modules/lean-client-js-node": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/lean-client-js-node/-/lean-client-js-node-2.0.1.tgz",
-      "integrity": "sha512-NQrIkV1CAW/fKzhI9qUc2687pSS/1L546ntJrkK9gv4qoxXXJBxQeagqTaV8O7T4Bsy2ow/JdsqIJ0LQ6ajCGw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/lean-client-js-node/-/lean-client-js-node-2.0.4.tgz",
+      "integrity": "sha512-Dx9PaB3vdt19hV6MyZuwCUb8jESmIPjxfEgLVMVBE/qvMUligPt1+Vj8O1OXFQu+GohoYI6/GqaEzTPzycYWHQ==",
       "dependencies": {
         "@types/node": "^9.4.6",
-        "lean-client-js-core": "^2.0.1"
+        "lean-client-js-core": "^2.0.4"
       }
+    },
+    "node_modules/lean-client-js-node/node_modules/@types/node": {
+      "version": "9.6.61",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.61.tgz",
+      "integrity": "sha512-/aKAdg5c8n468cYLy2eQrcR5k6chlbNwZNGUj3TboyPa2hcO2QAJcfymlqPzMiRj8B6nYKXjzQz36minFE0RwQ=="
     },
     "node_modules/typescript": {
       "version": "4.3.4",
@@ -56,66 +67,84 @@
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.5.0.tgz",
-      "integrity": "sha1-hyOdnhZrLXNSJFuKgTWXgEwdY6o=",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
       "engines": {
-        "node": ">=4.0.0 || >=6.0.0"
+        "node": ">=8.0.0 || >=10.0.0"
       }
     },
     "node_modules/vscode-languageserver": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-3.5.0.tgz",
-      "integrity": "sha1-0oCZvG3dqMHdFrcH5FThsd2uDbo=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
+      "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
       "dependencies": {
-        "vscode-languageserver-protocol": "^3.5.0",
-        "vscode-uri": "^1.0.1"
+        "vscode-languageserver-protocol": "3.16.0"
       },
       "bin": {
         "installServerIntoExtension": "bin/installServerIntoExtension"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.5.0.tgz",
-      "integrity": "sha1-Bnxcvidwl5U5jRGWksl+u6FFIgk=",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
       "dependencies": {
-        "vscode-jsonrpc": "^3.5.0",
-        "vscode-languageserver-types": "^3.5.0"
+        "vscode-jsonrpc": "6.0.0",
+        "vscode-languageserver-types": "3.16.0"
       }
     },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz",
+      "integrity": "sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA=="
+    },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.5.0.tgz",
-      "integrity": "sha1-5I15li8LjgLelV4/UkkI4rGcA3Q="
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
     },
     "node_modules/vscode-uri": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.1.tgz",
-      "integrity": "sha1-Eahr7+rDxKo+wIYjZRo8gabQu8g="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.2.tgz",
+      "integrity": "sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA=="
     }
   },
   "dependencies": {
     "@types/node": {
-      "version": "9.6.61",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.61.tgz",
-      "integrity": "sha512-/aKAdg5c8n468cYLy2eQrcR5k6chlbNwZNGUj3TboyPa2hcO2QAJcfymlqPzMiRj8B6nYKXjzQz36minFE0RwQ=="
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.6.1.tgz",
+      "integrity": "sha512-Sr7BhXEAer9xyGuCN3Ek9eg9xPviCF2gfu9kTfuU2HkTVAMYSDeX40fvpmo72n5nansg3nsBjuQBrsS28r+NUw=="
     },
     "lean-client-js-core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/lean-client-js-core/-/lean-client-js-core-2.0.1.tgz",
-      "integrity": "sha512-QGNAAB+RnFF2JQSw5mj6iInwhKVDPf1pYII/YU+SmWMNCO1R+n55ti8LCZcDeUvZlu/pybGgwZ9/3rq9cd10oA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/lean-client-js-core/-/lean-client-js-core-2.0.4.tgz",
+      "integrity": "sha512-jLZErvAHF0mfU+rC8UhPQdhypz2mwj0UgMhMYpRcY0srRU684mxcOcCERNd3D6crGJBEAM9QIN54m2HzWZ69YQ==",
       "requires": {
         "@types/node": "^9.4.6"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "9.6.61",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.61.tgz",
+          "integrity": "sha512-/aKAdg5c8n468cYLy2eQrcR5k6chlbNwZNGUj3TboyPa2hcO2QAJcfymlqPzMiRj8B6nYKXjzQz36minFE0RwQ=="
+        }
       }
     },
     "lean-client-js-node": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/lean-client-js-node/-/lean-client-js-node-2.0.1.tgz",
-      "integrity": "sha512-NQrIkV1CAW/fKzhI9qUc2687pSS/1L546ntJrkK9gv4qoxXXJBxQeagqTaV8O7T4Bsy2ow/JdsqIJ0LQ6ajCGw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/lean-client-js-node/-/lean-client-js-node-2.0.4.tgz",
+      "integrity": "sha512-Dx9PaB3vdt19hV6MyZuwCUb8jESmIPjxfEgLVMVBE/qvMUligPt1+Vj8O1OXFQu+GohoYI6/GqaEzTPzycYWHQ==",
       "requires": {
         "@types/node": "^9.4.6",
-        "lean-client-js-core": "^2.0.1"
+        "lean-client-js-core": "^2.0.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "9.6.61",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.61.tgz",
+          "integrity": "sha512-/aKAdg5c8n468cYLy2eQrcR5k6chlbNwZNGUj3TboyPa2hcO2QAJcfymlqPzMiRj8B6nYKXjzQz36minFE0RwQ=="
+        }
       }
     },
     "typescript": {
@@ -125,37 +154,41 @@
       "dev": true
     },
     "vscode-jsonrpc": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.5.0.tgz",
-      "integrity": "sha1-hyOdnhZrLXNSJFuKgTWXgEwdY6o="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
     },
     "vscode-languageserver": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-3.5.0.tgz",
-      "integrity": "sha1-0oCZvG3dqMHdFrcH5FThsd2uDbo=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
+      "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
       "requires": {
-        "vscode-languageserver-protocol": "^3.5.0",
-        "vscode-uri": "^1.0.1"
+        "vscode-languageserver-protocol": "3.16.0"
       }
     },
     "vscode-languageserver-protocol": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.5.0.tgz",
-      "integrity": "sha1-Bnxcvidwl5U5jRGWksl+u6FFIgk=",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
       "requires": {
-        "vscode-jsonrpc": "^3.5.0",
-        "vscode-languageserver-types": "^3.5.0"
+        "vscode-jsonrpc": "6.0.0",
+        "vscode-languageserver-types": "3.16.0"
       }
     },
+    "vscode-languageserver-textdocument": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz",
+      "integrity": "sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA=="
+    },
     "vscode-languageserver-types": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.5.0.tgz",
-      "integrity": "sha1-5I15li8LjgLelV4/UkkI4rGcA3Q="
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
     },
     "vscode-uri": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.1.tgz",
-      "integrity": "sha1-Eahr7+rDxKo+wIYjZRo8gabQu8g="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.2.tgz",
+      "integrity": "sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA=="
     }
   }
 }

--- a/lean-language-server/package.json
+++ b/lean-language-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lean-language-server",
-  "version": "2.0.4",
-  "description": "Language Server Protocol server for Lean",
+  "version": "3.0.0",
+  "description": "Language Server Protocol server for Lean 3",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "keywords": [],
@@ -19,10 +19,11 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@types/node": "^9.4.6",
+    "@types/node": "^16.6.1",
     "lean-client-js-node": "^2.0.4",
-    "vscode-languageserver": "^3.5.0",
-    "vscode-uri": "^1.0.1"
+    "vscode-languageserver": "^7.0.0",
+    "vscode-languageserver-textdocument": "^1.0.1",
+    "vscode-uri": "^3.0.2"
   },
   "devDependencies": {
     "typescript": "^4.3.4"

--- a/lean-language-server/src/index.ts
+++ b/lean-language-server/src/index.ts
@@ -1,8 +1,22 @@
 #!/usr/bin/env node
-import {Message, ProcessTransport, Server, Severity} from 'lean-client-js-node';
-import {CompletionItem, CompletionItemKind, createConnection, Definition, Diagnostic, DiagnosticSeverity, Hover,
-    InitializeParams, InitializeResult, Location, MarkedString, Position, ProposedFeatures, Range, ResponseError,
-    TextDocumentPositionParams, TextDocuments, TextDocumentSyncKind} from 'vscode-languageserver/node';
+import { ProcessTransport, Server, Severity } from 'lean-client-js-node';
+import {
+    CompletionItem,
+    CompletionItemKind,
+    Definition,
+    Diagnostic,
+    DiagnosticSeverity,
+    Hover,
+    InitializeResult,
+    Location,
+    MarkedString,
+    Position,
+    Range,
+    TextDocumentPositionParams,
+    TextDocumentSyncKind,
+    TextDocuments,
+    createConnection,
+} from 'vscode-languageserver/node';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
 


### PR DESCRIPTION
I'm playing with some minor tweaks (perhaps to remove some things from hover).

Updating to a recent `vscode-languageserver` seems to be fairly straightforward at least without many code changes.