### PR TITLE
Add SymbolKinds next to autocomplete and workspace searches

### DIFF
--- a/lean-client-js-core/package.json
+++ b/lean-client-js-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lean-client-js-core",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Interface to the Lean server",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/lean-client-js-core/src/commands.ts
+++ b/lean-client-js-core/src/commands.ts
@@ -74,15 +74,13 @@ export interface CompleteRequest extends Request {
 }
 
 export declare type SymbolKind
-    = 'axiom'
-    | 'const'
-    | 'constructor'
-    | 'field'
-    | 'class'
+    = 'class'
+    | 'definition'
+    | 'meta'
     | 'inductive'
     | 'instance'
+    | 'structure'
     | 'theorem'
-    | 'definition'
 
 export interface CompletionCandidate {
     type?: string;

--- a/lean-client-js-core/src/commands.ts
+++ b/lean-client-js-core/src/commands.ts
@@ -73,10 +73,22 @@ export interface CompleteRequest extends Request {
     skip_completions?: boolean;
 }
 
+export declare type SymbolKind
+    = 'axiom'
+    | 'const'
+    | 'constructor'
+    | 'field'
+    | 'class'
+    | 'inductive'
+    | 'instance'
+    | 'theorem'
+    | 'definition'
+
 export interface CompletionCandidate {
     type?: string;
     tactic_params?: string[];
     text: string;
+    kind?: SymbolKind;
     doc?: string;
 }
 
@@ -149,6 +161,7 @@ export interface SearchItem {
     source?: InfoSource;
     text: string;
     type: string;
+    kind?: SymbolKind;
     doc?: string;
 }
 


### PR DESCRIPTION
This is some prework for #45, and includes the new interface from https://github.com/leanprover-community/lean/pull/727.