### PR TITLE
Fix crash on Lean 3.51.1 by using new emscripten FS API

### DIFF
--- a/lean-client-js-browser/src/inprocess.ts
+++ b/lean-client-js-browser/src/inprocess.ts
@@ -109,7 +109,7 @@ export class InProcessTransport implements Transport {
             const BrowserFS = new FS();
             BrowserFS.initialize(libraryFS);
             const BFS = new EmscriptenFS(Module.FS, Module.PATH, Module.ERRNO_CODES, BrowserFS);
-            (Module.FS.mkdir || Module.FS.createPath)(Module.FS.root, 'library', true, true);
+            (Module.FS.createPath || Module.FS.createFolder)(Module.FS.root, 'library', true, true);
             Module.FS.mount(BFS, {root: '/'}, '/library');
             this.info = library.urls;
         }

--- a/lean-client-js-browser/src/inprocess.ts
+++ b/lean-client-js-browser/src/inprocess.ts
@@ -109,7 +109,7 @@ export class InProcessTransport implements Transport {
             const BrowserFS = new FS();
             BrowserFS.initialize(libraryFS);
             const BFS = new EmscriptenFS(Module.FS, Module.PATH, Module.ERRNO_CODES, BrowserFS);
-            Module.FS.createFolder(Module.FS.root, 'library', true, true);
+            (Module.FS.mkdir || Module.FS.createFolder)(Module.FS.root, 'library', true, true);
             Module.FS.mount(BFS, {root: '/'}, '/library');
             this.info = library.urls;
         }

--- a/lean-client-js-browser/src/inprocess.ts
+++ b/lean-client-js-browser/src/inprocess.ts
@@ -109,7 +109,7 @@ export class InProcessTransport implements Transport {
             const BrowserFS = new FS();
             BrowserFS.initialize(libraryFS);
             const BFS = new EmscriptenFS(Module.FS, Module.PATH, Module.ERRNO_CODES, BrowserFS);
-            (Module.FS.mkdir || Module.FS.createFolder)(Module.FS.root, 'library', true, true);
+            (Module.FS.mkdir || Module.FS.createPath)(Module.FS.root, 'library', true, true);
             Module.FS.mount(BFS, {root: '/'}, '/library');
             this.info = library.urls;
         }


### PR DESCRIPTION
`createFolder` no longer exists in new emscripten, it was removed in https://github.com/emscripten-core/emscripten/commit/e4933ea1e1c62e044fe829be714c9a4ba6272cb7.
`createPath` isn't an exact replacement, but does the job.

An exact replacement would use the `Module.PATH` API and call `Module.FS.mkdir`; but the former only exists in builds of Lean 3.51.1 onwards.

Lean 3.51.0 does not work either before or after this patch; its build settings were incorrect.